### PR TITLE
fix: comment out tw-animate-css and ignore pnpm-lock.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /.next/
 /out/
 
+# lockfile
+pnpm-lock.yaml
+
 # production
 /build
 
@@ -31,6 +34,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
+
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -9,19 +9,23 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "tw-animate-css";
+/* @import "tw-animate-css"; */
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/components/ParticleSystem.tsx
+++ b/src/components/ParticleSystem.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef } from "react";
 
 // Particle type definition
 type Particle = {
@@ -21,165 +21,166 @@ export default function ParticleSystem() {
   const rafIdRef = useRef<number | null>(null);
   const contextRef = useRef<CanvasRenderingContext2D | null>(null);
 
-  // Initialize particles based on screen size
-  const initParticles = () => {
-    if (!canvasRef.current) return;
-
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-    
-    // Calculate number of particles based on screen width (1 per 30px, max 50)
-    const particleCount = Math.min(Math.floor(width / 30), 50);
-    const particles: Particle[] = [];
-    
-    // Colors for particles
-    const colors = ['#6D28D9', '#8B5CF6']; // Two purple shades
-    
-    for (let i = 0; i < particleCount; i++) {
-      particles.push({
-        x: Math.random() * width,
-        y: Math.random() * height,
-        vx: (Math.random() - 0.5) * 2,
-        vy: (Math.random() - 0.5) * 2,
-        size: Math.random() * 3 + 1,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        opacity: Math.random() * 0.5 + 0.3,
-      });
-    }
-    
-    particlesRef.current = particles;
-  };
-
-  // Handle canvas resizing
-  const handleResize = () => {
-    if (!canvasRef.current || !contextRef.current) return;
-    
-    canvasRef.current.width = window.innerWidth;
-    canvasRef.current.height = window.innerHeight;
-    
-    // Re-initialize particles for new size
-    initParticles();
-  };
-
-  // Animation loop
-  const animate = () => {
-    const canvas = canvasRef.current;
-    const ctx = contextRef.current;
-    
-    if (!canvas || !ctx) return;
-    
-    // Clear canvas
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    
-    const particles = particlesRef.current;
-    const mousePos = mouseRef.current;
-    
-    // Update and draw particles
-    for (let i = 0; i < particles.length; i++) {
-      const p = particles[i];
-      
-      // Apply movement
-      p.x += p.vx;
-      p.y += p.vy;
-      
-      // Apply friction to slow down
-      p.vx *= 0.99;
-      p.vy *= 0.99;
-      
-      // Bounce off edges
-      if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
-      if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
-      
-      // Mouse interaction (gentle push)
-      const dx = p.x - mousePos.x;
-      const dy = p.y - mousePos.y;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      
-      if (distance < 100) {
-        const angle = Math.atan2(dy, dx);
-        const force = (100 - distance) / 500;
-        p.vx += Math.cos(angle) * force;
-        p.vy += Math.sin(angle) * force;
-      }
-      
-      // Draw particle
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fillStyle = p.color.replace(')', `, ${p.opacity})`).replace('rgb', 'rgba');
-      ctx.fill();
-      
-      // Draw connections to nearby particles
-      for (let j = i + 1; j < particles.length; j++) {
-        const p2 = particles[j];
-        const dx = p.x - p2.x;
-        const dy = p.y - p2.y;
-        const distance = Math.sqrt(dx * dx + dy * dy);
-        
-        if (distance < 100) {
-          ctx.beginPath();
-          ctx.moveTo(p.x, p.y);
-          ctx.lineTo(p2.x, p2.y);
-          // Make line opacity based on distance
-          const opacity = (100 - distance) / 100 * 0.2;
-          ctx.strokeStyle = `rgba(110, 110, 160, ${opacity})`;
-          ctx.lineWidth = 0.5;
-          ctx.stroke();
-        }
-      }
-    }
-    
-    // Continue animation loop
-    rafIdRef.current = requestAnimationFrame(animate);
-  };
-
   // Setup on component mount
   useEffect(() => {
+    // Initialize particles based on screen size
+    const initParticles = () => {
+      if (!canvasRef.current) return;
+
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      // Calculate number of particles based on screen width (1 per 30px, max 50)
+      const particleCount = Math.min(Math.floor(width / 30), 50);
+      const particles: Particle[] = [];
+
+      // Colors for particles
+      const colors = ["#6D28D9", "#8B5CF6"]; // Two purple shades
+
+      for (let i = 0; i < particleCount; i++) {
+        particles.push({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: (Math.random() - 0.5) * 2,
+          vy: (Math.random() - 0.5) * 2,
+          size: Math.random() * 3 + 1,
+          color: colors[Math.floor(Math.random() * colors.length)],
+          opacity: Math.random() * 0.5 + 0.3,
+        });
+      }
+
+      particlesRef.current = particles;
+    };
+
+    // Handle canvas resizing
+    const handleResize = () => {
+      if (!canvasRef.current || !contextRef.current) return;
+
+      canvasRef.current.width = window.innerWidth;
+      canvasRef.current.height = window.innerHeight;
+
+      // Re-initialize particles for new size
+      initParticles();
+    };
+
+    // Animation loop
+    const animate = () => {
+      const canvas = canvasRef.current;
+      const ctx = contextRef.current;
+
+      if (!canvas || !ctx) return;
+
+      // Clear canvas
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      const particles = particlesRef.current;
+      const mousePos = mouseRef.current;
+
+      // Update and draw particles
+      for (let i = 0; i < particles.length; i++) {
+        const p = particles[i];
+
+        // Apply movement
+        p.x += p.vx;
+        p.y += p.vy;
+
+        // Apply friction to slow down
+        p.vx *= 0.99;
+        p.vy *= 0.99;
+
+        // Bounce off edges
+        if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+        if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+
+        // Mouse interaction (gentle push)
+        const dx = p.x - mousePos.x;
+        const dy = p.y - mousePos.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance < 100) {
+          const angle = Math.atan2(dy, dx);
+          const force = (100 - distance) / 500;
+          p.vx += Math.cos(angle) * force;
+          p.vy += Math.sin(angle) * force;
+        }
+
+        // Draw particle
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+        ctx.fillStyle = p.color
+          .replace(")", `, ${p.opacity})`)
+          .replace("rgb", "rgba");
+        ctx.fill();
+
+        // Draw connections to nearby particles
+        for (let j = i + 1; j < particles.length; j++) {
+          const p2 = particles[j];
+          const dx = p.x - p2.x;
+          const dy = p.y - p2.y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance < 100) {
+            ctx.beginPath();
+            ctx.moveTo(p.x, p.y);
+            ctx.lineTo(p2.x, p2.y);
+            // Make line opacity based on distance
+            const opacity = ((100 - distance) / 100) * 0.2;
+            ctx.strokeStyle = `rgba(110, 110, 160, ${opacity})`;
+            ctx.lineWidth = 0.5;
+            ctx.stroke();
+          }
+        }
+      }
+
+      // Continue animation loop
+      rafIdRef.current = requestAnimationFrame(animate);
+    };
+
+    // Get canvas and context
     const canvas = canvasRef.current;
     if (!canvas) return;
-    
-    // Get context
-    const context = canvas.getContext('2d');
+
+    const context = canvas.getContext("2d");
     if (!context) return;
     contextRef.current = context;
-    
+
     // Set canvas size
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
-    
-    // Initialize particles
+
+    // Initialize and animate
     initParticles();
-    
-    // Start animation
     rafIdRef.current = requestAnimationFrame(animate);
-    
-    // Add event listeners
-    window.addEventListener('resize', handleResize);
-    window.addEventListener('mousemove', (e) => {
+
+    // Named mouse move handler (so we can remove it)
+    const handleMouseMove = (e: MouseEvent) => {
       mouseRef.current = { x: e.clientX, y: e.clientY };
-    });
-    
+    };
+
+    // Add event listeners
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("mousemove", handleMouseMove);
+
     // Cleanup on unmount
     return () => {
       if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current);
-      window.removeEventListener('resize', handleResize);
-      window.removeEventListener('mousemove', (e) => {
-        mouseRef.current = { x: e.clientX, y: e.clientY };
-      });
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("mousemove", handleMouseMove);
     };
-  }, []);
+  }, []); // No missing dependencies now
 
   return (
     <canvas
       ref={canvasRef}
       style={{
-        position: 'fixed',
+        position: "fixed",
         top: 0,
         left: 0,
-        width: '100%',
-        height: '100%',
+        width: "100%",
+        height: "100%",
         zIndex: -1,
-        pointerEvents: 'none',
+        pointerEvents: "none",
       }}
     />
   );
-} 
+}

--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -2,19 +2,20 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-interface CustomButtonProps {
+// Extend React's ButtonHTMLAttributes for native button props
+interface CustomButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  type?: "default" | "transparent";
+  variant?: "default" | "transparent";
   onClick?: () => void;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   className?: string;
-  [key: string]: any;
+  // No need for [key: string]: any; anymore
 }
 
 export function CustomButton({
   children,
-  type = "default",
+  variant = "default",
   onClick,
   leftIcon,
   rightIcon,
@@ -25,7 +26,7 @@ export function CustomButton({
     <Button
       onClick={onClick}
       className={cn(
-        type === "transparent" && "bg-transparent border border-primary hover:bg-primary/10",
+        variant === "transparent" && "bg-transparent border border-primary hover:bg-primary/10",
         className
       )}
       {...props}
@@ -35,4 +36,4 @@ export function CustomButton({
       {rightIcon && <span className="ml-1">{rightIcon}</span>}
     </Button>
   );
-} 
+}


### PR DESCRIPTION
Commented out @import "tw-animate-css" in globals.css file; which was breaking Tailwind styles on initial run.

Added pnpm-lock.yaml to .gitignore since it’s auto-generated by pnpm install.