### PR TITLE
(chore) Removed duplicate use of id="links"

### DIFF
--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -26,7 +26,7 @@ const Footer = () => {
 
           {/* Links Section */}
           <div
-            id="links"
+            id="footer-links"
             className="grid grid-cols-2 md:grid-cols-3 gap-8 col-span-2"
           >
             <div>
@@ -39,7 +39,7 @@ const Footer = () => {
                   <Link href="#">Integrations</Link>
                 </li>
                 <li>
-                  <Link href="#links">Changelog</Link>
+                  <Link href="#">Changelog</Link>
                 </li>
               </ul>
             </div>
@@ -47,7 +47,7 @@ const Footer = () => {
               <h3 className="font-semibold mb-4">Company</h3>
               <ul className="space-y-2">
                 <li>
-                  <Link href="#links">About us</Link>
+                  <Link href="#">About us</Link>
                 </li>
                 <li>
                   <Link href="mailto:support@devoter.xyz">Contact us</Link>


### PR DESCRIPTION
This PR aims to resolve #40 

- [x] Unique ID for Container: I changed the id of the div that contains the link columns from id="links" to id="footer-links". This makes the ID more specific and avoids potential conflicts with navigation anchors.

- [x] Updated Placeholder Links: I updated the href attribute for the "Changelog" and "About us" links. They were previously pointing to #links. I changed them to href="#" to remove the confusing self-reference, treating them as placeholders for now.