### PR TITLE
fix: remove "Community" nav item from Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 const navItems = [
   { label: "Features", href: "#features" },
   { label: "How it Works", href: "#workflow" },
-  { label: "Community", href: "#community" },
+
 ];
 
 export default function Navbar() {


### PR DESCRIPTION
removed community from nav bar, did not see the need for it