### PR TITLE
fix: remove "About us" link from Footer 

### DIFF
--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -48,9 +48,7 @@ const Footer = () => {
             <div>
               <h3 className="font-semibold mb-4">Company</h3>
               <ul className="space-y-2">
-                <li>
-                  <Link href="#">About us</Link>
-                </li>
+             
                 <li>
                   <Link href="mailto:support@devoter.xyz">Contact us</Link>
                 </li>


### PR DESCRIPTION
Removed the link as there is not page for it. we can add it back later once the page is added