### PR TITLE
feat: add warning for demo contact

### DIFF
--- a/src/components/contact/ContactContent.tsx
+++ b/src/components/contact/ContactContent.tsx
@@ -49,6 +49,12 @@ export default function ContactContent() {
               </p>
             </div>
 
+            {/* Warning: Demo Data */}
+            <div className="mb-4 p-4 bg-yellow-100 border-l-4 border-yellow-400 text-yellow-800 rounded">
+              <strong>Note:</strong> The contact information below is for
+              demonstration purposes only and does not represent real contact
+              details.
+            </div>
             <div className="space-y-6">
               {/* Email */}
               <Card className="p-6 hover:shadow-lg transition-shadow">


### PR DESCRIPTION
added warning for demo contact information in ContactContent component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prominent yellow note in the Get in Touch section indicating the contact details are for demonstration only, shown above the contact cards.
  * Uses accessible alert styling with clear “Note:” labeling to ensure visibility across devices and screen readers.
  * No interaction changes; existing contact information remains visible and unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->